### PR TITLE
Allow nullables in linked_relation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 Pipfile*
 build/
+__pycache__

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.0.16 - UNRELEASED
+===================
+
+* Allow nullables in ``linked_relation`` chains.
+
 
 0.0.15 - 2022-12-23
 ===================

--- a/adminutils/__init__.py
+++ b/adminutils/__init__.py
@@ -40,6 +40,10 @@ def linked_relation(
     def getter(self, obj):
         for attr in attribute_name.split("__"):
             obj = getattr(obj, attr)
+            if obj is None:
+                # Allow None values at any point in the chain
+                return None
+
         return admin_detail_link(
             obj,
             text=(

--- a/adminutils/actions.py
+++ b/adminutils/actions.py
@@ -42,6 +42,7 @@ def object_action(func, methods="POST"):
         if tool not in actions:
             raise http.Http404("Action does not exist")
         return func(self, request, *args, **kwargs)
+
     return view
 
 


### PR DESCRIPTION
Closes #1 

(Note: the new space in `adminutils/actions.py` comes from the new `divio/lint`).